### PR TITLE
fix(kubewarden): Kubewarden moved the compose file.

### DIFF
--- a/policy/CHANGELOG.md
+++ b/policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1
+
+Allow define the compose file to be used when updating docusaurus update policy
+
 ## 0.1.0
 
 Init release

--- a/policy/Policy.yaml
+++ b/policy/Policy.yaml
@@ -5,7 +5,7 @@ url: "https://github.com/olblak/updatecli-policy-docusaurus"
 documentation: "https://github.com/olblak/updatecli-policy-docusaurus/README.md"
 source: "https://github.com/olblak/updatecli-policy-docusaurus.git"
 
-version: 0.1.0
+version: 0.1.1
 licenses:
   - "Apache-2.0 license"
 description: |

--- a/policy/updatecli.d/update-compose-policy.yaml
+++ b/policy/updatecli.d/update-compose-policy.yaml
@@ -24,7 +24,7 @@ targets:
     scmid: default
     disablesourceinput: true
     spec:
-      file: update-compose.yaml
+      file: {{ .composeFile }} 
       matchpattern: '(policy: ghcr.io/olblak/policies/rancher/docusaurus/{{ lower .project }}:)(.*)'
       replacepattern: '${1}{{ source "digest"}}'
 

--- a/policy/values.d/epinio.yaml
+++ b/policy/values.d/epinio.yaml
@@ -1,5 +1,6 @@
 project: "Epinio"
 repository: "epinio/epinio"
+composeFile: "update-compose.yaml"
 
 scm:
   # GitHub user associated to the commit message

--- a/policy/values.d/fleet.yaml
+++ b/policy/values.d/fleet.yaml
@@ -1,5 +1,6 @@
 project: "Fleet"
 repository: "rancher/fleet"
+composeFile: "update-compose.yaml"
 
 scm:
   # GitHub user associated to the commit message

--- a/policy/values.d/kubewarden.yaml
+++ b/policy/values.d/kubewarden.yaml
@@ -1,5 +1,6 @@
 project: "Kubewarden"
 repository: "kubewarden/kubewarden-controller"
+composeFile: "updatecli/updatecli-compose.yaml"
 
 scm:
   # GitHub user associated to the commit message


### PR DESCRIPTION
Recently the Kubewarden project moved the compose files under the updatecli directory to keep all of them at the same place. However, this policy has the file path hard coded. Therefore, this commit adds a new value to allow defining the file path of the compose file where the policy should be updated.